### PR TITLE
Update jaeger exporter config for open-telemetry v0.37+

### DIFF
--- a/otel/controlplane/overlays/jaeger/otel-collector-config.yaml
+++ b/otel/controlplane/overlays/jaeger/otel-collector-config.yaml
@@ -18,7 +18,8 @@ exporters:
     # This is the jaeger pod's IP, and is hardcoded for the demo, 
     # since there is no kube-proxy on the master node
     endpoint: "10.64.3.4:14250"
-    insecure: true
+    tls:
+      insecure: true
 service:
   pipelines:
     traces:


### PR DESCRIPTION
jaeger exporter changed config to 
```
exporters:
  jaeger:
    endpoint: jaeger-all-in-one:14250
    tls:
      cert_file: file.cert
      key_file: file.key
  jaeger/2:
    endpoint: jaeger-all-in-one:14250
    tls:
      insecure: true
```
https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.37.1/exporter/jaegerexporter